### PR TITLE
🔀 :: 실패할때 전용 Alert Step

### DIFF
--- a/iOS/Sources/Application/Flow/Step/GCMSStep.swift
+++ b/iOS/Sources/Application/Flow/Step/GCMSStep.swift
@@ -5,6 +5,7 @@ import Service
 enum GCMSStep: Step {
     // MARK: Global
     case alert(title: String?, message: String?, style: UIAlertController.Style, actions: [UIAlertAction])
+    case failureAlert(title: String?, message: String, action: UIAlertAction?)
     case dismiss
     
     // MARK: OnBoading


### PR DESCRIPTION
## 개요
확인버튼만 있는 Alert 띄우기 전용 Step 

## 작업사항
GCMSStep에 failureAlert(title: String?, message: String, action: UIAlertAction?) 추가


## 사용방법
```Swift
func presentToFailureAlert(title: String?, message: String?, action: UIAlertAction?) -> FlowContributors {
    let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
        
    if let action = action {
        alert.addAction(action)
    } else {
        alert.addAction(.init(title: "취소", style: .default))
    }
    
    return .none
}
```

## 기타

