### PR TITLE
🔀 :: 메모리 아끼기!

### DIFF
--- a/iOS/Sources/Presentation/Scene/Main/Common/Cell/ClubListCell.swift
+++ b/iOS/Sources/Presentation/Scene/Main/Common/Cell/ClubListCell.swift
@@ -8,6 +8,7 @@ final class ClubListCell: BaseCollectionViewCell<ClubList> {
     override func prepareForReuse() {
         super.prepareForReuse()
         model = nil
+        clubView.cancelImageDownload()
     }
     
     // MARK: - UI

--- a/iOS/Sources/Presentation/Scene/Main/Common/ClubView.swift
+++ b/iOS/Sources/Presentation/Scene/Main/Common/ClubView.swift
@@ -46,6 +46,9 @@ final class ClubView: UIView {
                                    options: [])
         nameLabel.text = club.title
     }
+    public func cancelImageDownload() {
+        clubBannerView.kf.cancelDownloadTask()
+    }
 }
 
 // MARK: - UI

--- a/iOS/Sources/Presentation/Scene/Main/DetailClub/VC/DetailClubVC.swift
+++ b/iOS/Sources/Presentation/Scene/Main/DetailClub/VC/DetailClubVC.swift
@@ -68,7 +68,7 @@ final class DetailClubVC: BaseVC<DetailClubReactor> {
         $0.setTitle("신청하기", for: .normal)
         $0.setTitleColor(GCMSAsset.Colors.gcmsGray1.color, for: .normal)
     }
-    private let statusButton = UIBarButtonItem(image: .init(systemName: "gearshape")?.tintColor(.white), style: .plain, target: nil, action: nil)
+    private lazy var statusButton = UIBarButtonItem(image: .init(systemName: "gearshape")?.tintColor(.white), style: .plain, target: nil, action: nil)
     
     // MARK: - UI
     override func addView() {


### PR DESCRIPTION
## 개요
로직 변경에 따라서 미리 setRightBar가 아닌 판별 후 setRightBar가 되었기에 lazy var로 작게나마 메모리를 아낍니다
clubListVC에서 cell이 prepareForReuse가 호출되면 이미지 다운로드를 cancel합니다

## 작업사항
statusButton의 선언법 변경

## 변경로직
statusButton 선언

### 변경전
```swift
private let statusButton
```

### 변경후
```swift
private lazy var statusButton
```

