### PR TITLE
🔀 :: cell에서 prepareForReuse가 불러지면 이미지 다운로드는 cancel합니다

### DIFF
--- a/iOS/Sources/Presentation/Scene/Main/ClubMember/View/Cell/ApplicantCell.swift
+++ b/iOS/Sources/Presentation/Scene/Main/ClubMember/View/Cell/ApplicantCell.swift
@@ -89,6 +89,7 @@ final class ApplicantCell: BaseTableViewCell<User> {
         super.prepareForReuse()
         model = nil
         disposeBag = DisposeBag()
+        profileImageView.kf.cancelDownloadTask()
     }
     
     override func bind(_ model: User) {

--- a/iOS/Sources/Presentation/Scene/Main/ClubMember/View/Cell/StatusMemberCell.swift
+++ b/iOS/Sources/Presentation/Scene/Main/ClubMember/View/Cell/StatusMemberCell.swift
@@ -91,6 +91,7 @@ final class StatusMemberCell: BaseTableViewCell<Member> {
         super.prepareForReuse()
         model = nil
         disposeBag = DisposeBag()
+        profileImageView.kf.cancelDownloadTask()
     }
     
     override func bind(_ model: Member) {

--- a/iOS/Sources/Presentation/Scene/Main/DetailClub/View/Cell/ClubMemberCell.swift
+++ b/iOS/Sources/Presentation/Scene/Main/DetailClub/View/Cell/ClubMemberCell.swift
@@ -17,6 +17,7 @@ final class ClubMemberCell: BaseCollectionViewCell<User> {
     override func prepareForReuse() {
         super.prepareForReuse()
         model = nil
+        profileImageView.kf.cancelDownloadTask()
     }
     
     // MARK: - UI

--- a/iOS/Sources/Presentation/Scene/Main/MemberAppend/View/Cell/StudentCell.swift
+++ b/iOS/Sources/Presentation/Scene/Main/MemberAppend/View/Cell/StudentCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Service
+import Kingfisher
 
 final class StudentCell: BaseTableViewCell<User> {
     // MARK: - Properties
@@ -23,6 +24,7 @@ final class StudentCell: BaseTableViewCell<User> {
     override func prepareForReuse() {
         super.prepareForReuse()
         model = nil
+        profileImageView.kf.cancelDownloadTask()
     }
     // MARK: - UI
     override func addView() {


### PR DESCRIPTION
## 개요
cell에서 prepareForReuse가 불리면 이미지 다운로드는 cancel

## 작업사항
image를 다운로드하는 cell 모두 prepareForReuse가 불릴때 image 다운로드는 cancel

## 변경로직
image download cancel 로직

### 변경전
```swift
    override func prepareForReuse() {
        super.prepareForReuse()
        model = nil
    }
```

### 변경후
```swift
    override func prepareForReuse() {
        super.prepareForReuse()
        model = nil
        profileImageView.kf.cancelDownloadTask()
    }
```


