### PR TITLE
🔀 :: delete route / -> /delete

### DIFF
--- a/Service/Sources/Data/DataSource/Remote/API/ClubAPI.swift
+++ b/Service/Sources/Data/DataSource/Remote/API/ClubAPI.swift
@@ -28,8 +28,10 @@ extension ClubAPI: GCMSAPI {
             return "/list"
         case .clubDetail:
             return "/detail"
-        case .createNewClub, .updateClub, .deleteClub:
+        case .createNewClub, .updateClub:
             return "/"
+        case .deleteClub:
+            return "/delete"
         case .clubMember:
             return "/members"
         case .clubApplicant:


### PR DESCRIPTION
## 개요
/으로 동아리 삭제 요청 가던걸 /delete로 요청 보내게

## 작업사항
delete request의 urlPath를 /에서 /delete로 

## 변경로직
club delete request urlPath 변경

### 변경전
```swift
        case .createNewClub, .updateClub, .deleteClub:
            return "/"
```

### 변경후
```swift
        case .createNewClub, .updateClub:
            return "/"
        case .deleteClub:
            return "/delete"
```
