### PR TITLE
🔀 :: 애플 로그인에 기능 추가

### DIFF
--- a/Service/Sources/DI/UseCaseAssembly.swift
+++ b/Service/Sources/DI/UseCaseAssembly.swift
@@ -141,5 +141,15 @@ public final class UseCaseAssembly: Assembly {
                 guestRepository: r.resolve(GuestRepository.self)!
             )
         }
+        container.register(IssueGuestTokenUseCase.self) { r in
+            IssueGuestTokenUseCase(
+                guestRepository: r.resolve(GuestRepository.self)!
+            )
+        }
+        container.register(RevokeGuestTokenUseCase.self) { r in
+            RevokeGuestTokenUseCase(
+                guestRepository: r.resolve(GuestRepository.self)!
+            )
+        }
     }
 }

--- a/Service/Sources/Data/DataSource/Local/Keychain/Keychain.swift
+++ b/Service/Sources/Data/DataSource/Local/Keychain/Keychain.swift
@@ -4,6 +4,7 @@ enum KeychainAccountType: String {
     case accessToken = "ACCESS-TOKEN"
     case refreshToken = "REFRESH-TOKEN"
     case expiredAt = "EXPIRED-AT"
+    case guestRefresh = "GUEST-REFRESH-TOKEN"
 }
 final class Keychain {
     static let shared = Keychain()

--- a/Service/Sources/Data/DataSource/Local/Keychain/KeychainLocal.swift
+++ b/Service/Sources/Data/DataSource/Local/Keychain/KeychainLocal.swift
@@ -40,4 +40,16 @@ final class KeychainLocal {
     func deleteExpiredAt() {
         keychain.delete(type: .expiredAt)
     }
+    
+    func saveGuestRefreshToken(_ token: String) {
+        keychain.save(type: .guestRefresh, value: token)
+    }
+    
+    func fetchGuestRefreshToken() throws -> String {
+        return try keychain.load(type: .guestRefresh)
+    }
+    
+    func deleteGuestRefreshToken() {
+        keychain.delete(type: .guestRefresh)
+    }
 }

--- a/Service/Sources/Data/DataSource/Local/UserDefaults/UserDefaultsLocal.swift
+++ b/Service/Sources/Data/DataSource/Local/UserDefaults/UserDefaultsLocal.swift
@@ -2,12 +2,21 @@ import Foundation
 
 public final class UserDefaultsLocal {
     public enum forKeys {
+        public static let isGuest = "isguest"
         public static let isApple = "isapple"
     }
     public static let shared = UserDefaultsLocal()
     private init() {}
     private let preferences = UserDefaults.standard
     
+    public var isGuest: Bool {
+        get {
+            preferences.bool(forKey: forKeys.isGuest)
+        }
+        set {
+            preferences.set(newValue, forKey: forKeys.isGuest)
+        }
+    }
     public var isApple: Bool {
         get {
             preferences.bool(forKey: forKeys.isApple)

--- a/Service/Sources/Data/DataSource/Remote/API/GCMSAPI.swift
+++ b/Service/Sources/Data/DataSource/Remote/API/GCMSAPI.swift
@@ -9,7 +9,7 @@ protocol GCMSAPI: TargetType, JWTTokenAuthorizable {
 
 extension GCMSAPI {
     var baseURL: URL {
-        return URL(string: "http://gsm.o-r.kr:4000")!
+        return URL(string: "http://3.36.15.183:4000")!
     }
     var path: String {
         return domain.url + urlPath

--- a/Service/Sources/Data/DataSource/Remote/API/GuestAPI.swift
+++ b/Service/Sources/Data/DataSource/Remote/API/GuestAPI.swift
@@ -3,6 +3,8 @@ import Moya
 enum GuestAPI {
     case guestClubList(type: ClubType)
     case guestClubDetail(query: ClubRequestQuery)
+    case tokenIssue(idToken: String, code: String)
+    case tokenRevoke(refreshToken: String)
 }
 
 extension GuestAPI: GCMSAPI {
@@ -16,6 +18,10 @@ extension GuestAPI: GCMSAPI {
             return "/list"
         case .guestClubDetail:
             return "/detail"
+        case .tokenIssue:
+            return "/apple"
+        case .tokenRevoke:
+            return "/apple/revoke"
         }
     }
     
@@ -23,6 +29,8 @@ extension GuestAPI: GCMSAPI {
         switch self {
         case .guestClubList, .guestClubDetail:
             return .get
+        case .tokenIssue, .tokenRevoke:
+            return .post
         }
     }
     
@@ -37,14 +45,20 @@ extension GuestAPI: GCMSAPI {
                 "q": q.q,
                 "type": q.type
             ], encoding: URLEncoding.queryString)
+        case let .tokenIssue(idToken, code):
+            return .requestParameters(parameters: [
+                "idToken": idToken,
+                "code": code
+            ], encoding: JSONEncoding.default)
+        case let .tokenRevoke(refreshToken):
+            return .requestParameters(parameters: [
+                "refreshToken": refreshToken
+            ], encoding: JSONEncoding.default)
         }
     }
     
     var jwtTokenType: JWTTokenType? {
-        switch self {
-        case .guestClubList, .guestClubDetail:
-            return JWTTokenType.none
-        }
+        return JWTTokenType.none
     }
     
     var errorMapper: [Int: GCMSError]?{

--- a/Service/Sources/Data/DataSource/Remote/DataMapping/Guest/GuestRefreshTokenResponse.swift
+++ b/Service/Sources/Data/DataSource/Remote/DataMapping/Guest/GuestRefreshTokenResponse.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct GuestRefreshTokenResponse: Decodable {
+    let refreshToken: String
+    
+    enum CodingKeys: String, CodingKey {
+        case refreshToken = "refresh_token"
+    }
+}

--- a/Service/Sources/Data/DataSource/Remote/DataSource/GuestRemote.swift
+++ b/Service/Sources/Data/DataSource/Remote/DataSource/GuestRemote.swift
@@ -14,4 +14,13 @@ final class GuestRemote: BaseRemote<GuestAPI> {
             .map(DetailClubResponse.self)
             .map { $0.toDomain() }
     }
+    func fetchGuestRefreshToken(idToken: String, code: String) -> Single<String> {
+        request(.tokenIssue(idToken: idToken, code: code))
+            .map(GuestRefreshTokenResponse.self)
+            .map(\.refreshToken)
+    }
+    func revokeGuestToken(refreshToken: String) -> Completable {
+        request(.tokenRevoke(refreshToken: refreshToken))
+            .asCompletable()
+    }
 }

--- a/Service/Sources/Data/Repositories/DefaultGuestRepository.swift
+++ b/Service/Sources/Data/Repositories/DefaultGuestRepository.swift
@@ -4,6 +4,7 @@ import Foundation
 final class DefaultGuestRepository: GuestRepository {
     private let guestRemote = GuestRemote.shared
     private let clubLocal = ClubLocal.shared
+    private let keychain = KeychainLocal.shared
     
     func fetchGuestClubList(type: ClubType) -> Observable<[ClubList]> {
         OfflineCache<[ClubList]>()
@@ -14,5 +15,19 @@ final class DefaultGuestRepository: GuestRepository {
     }
     func fetchGuestDetailClub(query: ClubRequestQuery) -> Single<Club> {
         guestRemote.fetchGuestDetailClub(query: query)
+    }
+    func issueGuestToken(idToken: String, code: String) -> Completable {
+        guestRemote.fetchGuestRefreshToken(idToken: idToken, code: code)
+            .asObservable()
+            .do(onNext: { self.keychain.saveGuestRefreshToken($0) })
+                .asSingle()
+                .asCompletable()
+    }
+    func revokeGuestToken() -> Completable {
+        do {
+            return guestRemote.revokeGuestToken(refreshToken: try keychain.fetchGuestRefreshToken())
+        } catch {
+            return Completable.error(GCMSError.noInternet)
+        }
     }
 }

--- a/Service/Sources/Domain/Repositories/GuestRepository.swift
+++ b/Service/Sources/Domain/Repositories/GuestRepository.swift
@@ -4,4 +4,6 @@ import Foundation
 public protocol GuestRepository {
     func fetchGuestClubList(type: ClubType) -> Observable<[ClubList]>
     func fetchGuestDetailClub(query: ClubRequestQuery) -> Single<Club>
+    func issueGuestToken(idToken: String, code: String) -> Completable
+    func revokeGuestToken() -> Completable
 }

--- a/Service/Sources/Domain/UseCases/Auth/CheckIsLoginedUseCase.swift
+++ b/Service/Sources/Domain/UseCases/Auth/CheckIsLoginedUseCase.swift
@@ -8,6 +8,13 @@ public struct CheckIsLoginedUseCase {
     private let authRepository: AuthRepository
     
     public func execute() -> Completable {
-        return authRepository.refresh()
+        if UserDefaultsLocal.shared.isApple {
+            return Completable.create { com in
+                com(.completed)
+                return Disposables.create()
+            }
+        } else {
+            return authRepository.refresh()
+        }
     }
 }

--- a/Service/Sources/Domain/UseCases/Guest/IssueGuestTokenUseCase.swift
+++ b/Service/Sources/Domain/UseCases/Guest/IssueGuestTokenUseCase.swift
@@ -1,0 +1,13 @@
+import RxSwift
+
+public struct IssueGuestTokenUseCase {
+    public init(guestRepository: GuestRepository) {
+        self.guestRepository = guestRepository
+    }
+    
+    private let guestRepository: GuestRepository
+    
+    public func execute(idToken: String, code: String) -> Completable {
+        guestRepository.issueGuestToken(idToken: idToken, code: code)
+    }
+}

--- a/Service/Sources/Domain/UseCases/Guest/RevokeGuestTokenUseCase.swift
+++ b/Service/Sources/Domain/UseCases/Guest/RevokeGuestTokenUseCase.swift
@@ -1,0 +1,13 @@
+import RxSwift
+
+public struct RevokeGuestTokenUseCase {
+    public init(guestRepository: GuestRepository) {
+        self.guestRepository = guestRepository
+    }
+    
+    private let guestRepository: GuestRepository
+    
+    public func execute() -> Completable {
+        guestRepository.revokeGuestToken()
+    }
+}

--- a/iOS/Sources/Application/DI/Assembly/ReactorAssembly.swift
+++ b/iOS/Sources/Application/DI/Assembly/ReactorAssembly.swift
@@ -6,14 +6,16 @@ final class ReactorAssembly: Assembly {
     func assemble(container: Container) {
         container.register(OnBoardingReactor.self) { r in
              OnBoardingReactor(
-                loginUseCase: r.resolve(LoginUseCase.self)!
+                loginUseCase: r.resolve(LoginUseCase.self)!,
+                issueGuestTokenUseCase: r.resolve(IssueGuestTokenUseCase.self)!
             )
         }
         
         container.register(HomeReactor.self) { r in
              HomeReactor(
                 fetchClubListsUseCase: r.resolve(FetchClubListUseCase.self)!,
-                fetchGuestClubListUseCase: r.resolve(FetchGuestClubListUseCase.self)!
+                fetchGuestClubListUseCase: r.resolve(FetchGuestClubListUseCase.self)!,
+                revokeGuestTokenUseCase: r.resolve(RevokeGuestTokenUseCase.self)!
             )
         }
         

--- a/iOS/Sources/Presentation/Scene/Auth/OnBoarding/Reactor/OnBoardingReactor.swift
+++ b/iOS/Sources/Presentation/Scene/Auth/OnBoarding/Reactor/OnBoardingReactor.swift
@@ -19,6 +19,7 @@ final class OnBoardingReactor: Reactor, Stepper {
         case googleSigninButtonDidTap(UIViewController)
         case googleSigninCompleted
         case appleSigninCompleted
+        case appleIdTokenReceived(String)
         case appleSigninFailed
         case guestSigninButtonDidTap
     }
@@ -54,6 +55,8 @@ extension OnBoardingReactor {
             return signinFailed(message: "알 수 없는 이유로 로그인이 실패했습니다.")
         case .googleSigninCompleted:
             return googleSigninCompleted()
+        case let .appleIdTokenReceived(token):
+            return .empty()
         }
         return .empty()
     }

--- a/iOS/Sources/Presentation/Scene/Auth/OnBoarding/VC/OnBoardingVC.swift
+++ b/iOS/Sources/Presentation/Scene/Auth/OnBoarding/VC/OnBoardingVC.swift
@@ -179,9 +179,9 @@ extension OnBoardingVC: ASAuthorizationControllerDelegate, ASAuthorizationContro
             let idToken = String(data: cred.identityToken ?? .init(), encoding: .utf8) ?? .init()
             let code = String(data: cred.authorizationCode ?? .init(), encoding: .utf8) ?? .init()
             self.reactor?.action.onNext(.appleIdTokenReceived(idToken: idToken, code: code))
+        } else {
+            self.reactor?.action.onNext(.appleSigninCompleted)
         }
-        
-        self.reactor?.action.onNext(.appleSigninCompleted)
     }
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         self.reactor?.action.onNext(.appleSigninFailed)

--- a/iOS/Sources/Presentation/Scene/Auth/OnBoarding/VC/OnBoardingVC.swift
+++ b/iOS/Sources/Presentation/Scene/Auth/OnBoarding/VC/OnBoardingVC.swift
@@ -175,6 +175,13 @@ extension OnBoardingVC: ASAuthorizationControllerDelegate, ASAuthorizationContro
         self.view.window ?? .init()
     }
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let cred = authorization.credential as? ASAuthorizationAppleIDCredential {
+            print(String(data: cred.identityToken ?? .init(), encoding: .utf8))
+            print(String(data: cred.authorizationCode ?? .init(), encoding: .utf8))
+        } else {
+            
+        }
+        
         self.reactor?.action.onNext(.appleSigninCompleted)
     }
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {

--- a/iOS/Sources/Presentation/Scene/Auth/OnBoarding/VC/OnBoardingVC.swift
+++ b/iOS/Sources/Presentation/Scene/Auth/OnBoarding/VC/OnBoardingVC.swift
@@ -176,10 +176,9 @@ extension OnBoardingVC: ASAuthorizationControllerDelegate, ASAuthorizationContro
     }
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         if let cred = authorization.credential as? ASAuthorizationAppleIDCredential {
-            print(String(data: cred.identityToken ?? .init(), encoding: .utf8))
-            print(String(data: cred.authorizationCode ?? .init(), encoding: .utf8))
-        } else {
-            
+            let idToken = String(data: cred.identityToken ?? .init(), encoding: .utf8) ?? .init()
+            let code = String(data: cred.authorizationCode ?? .init(), encoding: .utf8) ?? .init()
+            self.reactor?.action.onNext(.appleIdTokenReceived(idToken: idToken, code: code))
         }
         
         self.reactor?.action.onNext(.appleSigninCompleted)

--- a/iOS/Sources/Presentation/Scene/Main/DetailClub/Reactor/DetailClubReactor.swift
+++ b/iOS/Sources/Presentation/Scene/Main/DetailClub/Reactor/DetailClubReactor.swift
@@ -106,7 +106,7 @@ private extension DetailClubReactor {
     func viewDidLoad() -> Observable<Mutation> {
         let start = Observable.just(Mutation.setIsLoading(true))
         let task: Single<Club>
-        task = UserDefaultsLocal.shared.isApple
+        task = UserDefaultsLocal.shared.isGuest
         ? fetchGuestDetailClubUseCase.execute(query: query)
         : fetchDetailClubUseCase.execute(query: query)
         

--- a/iOS/Sources/Presentation/Scene/Main/DetailClub/VC/DetailClubVC.swift
+++ b/iOS/Sources/Presentation/Scene/Main/DetailClub/VC/DetailClubVC.swift
@@ -244,7 +244,7 @@ final class DetailClubVC: BaseVC<DetailClubReactor> {
                 }
                 owner.contactDescriptionLabel.text = item.contact
                 owner.navigationItem.configTitle(title: item.title)
-                owner.applyButton.isHidden = UserDefaultsLocal.shared.isApple
+                owner.applyButton.isHidden = UserDefaultsLocal.shared.isGuest
             }
             .disposed(by: disposeBag)
         

--- a/iOS/Sources/Presentation/Scene/Main/Home/VC/HomeVC.swift
+++ b/iOS/Sources/Presentation/Scene/Main/Home/VC/HomeVC.swift
@@ -25,6 +25,10 @@ final class HomeVC: TabmanViewController, View {
                                                     style: .plain,
                                                     target: nil,
                                                     action: nil)
+    private lazy var guestExitButton = UIBarButtonItem(image: .init(systemName: "gearshape.fill")?.tintColor(GCMSAsset.Colors.gcmsGray4.color),
+                                                       style: .plain,
+                                                       target: nil,
+                                                       action: nil)
     private lazy var indicator = AnimationView(name: "GCMS-Indicator").then {
         $0.contentMode = .scaleAspectFit
         $0.loopMode = .loop
@@ -105,7 +109,9 @@ private extension HomeVC {
     }
     func configNavigation(){
         self.navigationItem.leftBarButtonItem = UIBarButtonItem.init(customView: titleLabel)
-        if UserDefaultsLocal.shared.isApple {
+        if UserDefaultsLocal.shared.isGuest && UserDefaultsLocal.shared.isApple {
+            self.navigationItem.setRightBarButtonItems([guestLogoutButton, guestExitButton], animated: true)
+        } else if UserDefaultsLocal.shared.isGuest {
             self.navigationItem.setRightBarButton(guestLogoutButton, animated: true)
         } else {
             self.navigationItem.setRightBarButtonItems([myPageButton, newClubButton], animated: true)
@@ -131,6 +137,11 @@ private extension HomeVC {
         
         guestLogoutButton.rx.tap
             .map { _ in Reactor.Action.guestLogoutButtonDidTap }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        guestExitButton.rx.tap
+            .map { _ in Reactor.Action.appleExitButtonDidTap }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 개요
애플 로그인과 게스트 로그인을 약간 분리
애플 로그인 시 HomeVC에서 회원탈퇴 버튼 추가
애플 로그인 시 refreshToken 지급 받는 로직 추가
애플 로그인 탈퇴 시 refreshToken revoke 로직 추가

## 작업사항
애플 로그인 로직 추가

## 변경로직
애플 로그인 할때 완전히 게스트와 동일하게 취급하던 방식을 약간 분리
