### PR TITLE
🔀:: 로그인 부분 Auth 디자인과 다른 부분 수정

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -111,7 +111,7 @@
     {
       "identity" : "realm-core",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/realm/realm-core.git",
+      "location" : "https://github.com/realm/realm-core",
       "state" : {
         "revision" : "b77443ca7fa25407869ca537bf3ae912b1427bff",
         "version" : "12.13.0"

--- a/iOS/Sources/Presentation/Scene/Auth/OnBoarding/OnBoardingVC.swift
+++ b/iOS/Sources/Presentation/Scene/Auth/OnBoarding/OnBoardingVC.swift
@@ -19,16 +19,19 @@ final class OnBoardingVC: BaseVC<OnBoardingReactor> {
         $0.image = GCMSAsset.Images.gcmsgLogo.image.withRenderingMode(.alwaysOriginal)
     }
     private let tosStackView = UIStackView().then {
-        $0.spacing = 10
+        $0.spacing = 18
         $0.axis = .horizontal
+        $0.alignment = .center
     }
     private let termsOfServiceButton = UIButton().then {
         $0.setTitle("서비스 이용약관", for: .normal)
         $0.titleLabel?.font = .systemFont(ofSize: 14)
         $0.setTitleColor(GCMSAsset.Colors.gcmsGray4.color, for: .normal)
     }
-    private let betweenButtonView = UIView().then {
-        $0.backgroundColor = GCMSAsset.Colors.gcmsGray4.color
+    private let betweenButtonView = UILabel().then {
+        $0.text = "|"
+        $0.font = .boldSystemFont(ofSize: 14)
+        $0.textColor = GCMSAsset.Colors.gcmsGray4.color
     }
     private let privacyButton = UIButton().then {
         $0.setTitle("개인정보 처리 방침", for: .normal)
@@ -54,16 +57,13 @@ final class OnBoardingVC: BaseVC<OnBoardingReactor> {
                 .centerX(.toSuperview())
 
             tosStackView.layout
-                .bottom(.to(view.safeAreaLayoutGuide).bottom, .equal(-24))
+                .bottom(.to(view.safeAreaLayoutGuide).bottom, .equal(-18))
                 .centerX(.toSuperview())
 
             gauthSigninButton.layout
-                .bottom(.to(tosStackView).top, .equal(-8))
-                .horizontal(.toSuperview(), .equal(16))
+                .bottom(.to(tosStackView).top, .equal(-36))
+                .horizontal(.toSuperview(), .equal(20))
                 .height(50)
-
-            betweenButtonView.layout
-                .size(width: .equal(2), height: .equal(16))
         }
     }
     override func setup() {


### PR DESCRIPTION
## 개요
로그인 부분 Auth 디자인과 다른 부분 수정하였습니다.

## 작업사항
GAuth 버튼을 이용약관, 개인정보처리방침과 거리를 벌렸습니다.
betweenButtonView가 안 보이던 것을 Label로 바꾸어 보이게 하였습니다.

## 변경로직


### 변경전


### 변경후
![image](https://user-images.githubusercontent.com/81280223/226509331-88cd67da-7c98-46e5-b6f1-dae4a7135c4b.png)


## 사용방법


## 기타

