### PR TITLE
🔀 :: 마이페이지 프로필이미지 디자인과 다른 부분 수정

### DIFF
--- a/iOS/Derived/Sources/TuistAssets+GCMS.swift
+++ b/iOS/Derived/Sources/TuistAssets+GCMS.swift
@@ -68,10 +68,20 @@ public final class GCMSColors {
   }()
 
   #if canImport(SwiftUI)
+  private var _swiftUIColor: Any? = nil
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  public private(set) lazy var swiftUIColor: SwiftUI.Color = {
-    SwiftUI.Color(asset: self)
-  }()
+  public private(set) var swiftUIColor: SwiftUI.Color {
+    get {
+      if self._swiftUIColor == nil {
+        self._swiftUIColor = SwiftUI.Color(asset: self)
+      }
+
+      return self._swiftUIColor as! SwiftUI.Color
+    }
+    set {
+      self._swiftUIColor = newValue
+    }
+  }
   #endif
 
   fileprivate init(name: String) {
@@ -94,8 +104,8 @@ public extension GCMSColors.Color {
 }
 
 #if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
 public extension SwiftUI.Color {
-  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
   init(asset: GCMSColors) {
     let bundle = GCMSResources.bundle
     self.init(asset.name, bundle: bundle)

--- a/iOS/Derived/Sources/TuistFonts+GCMS.swift
+++ b/iOS/Derived/Sources/TuistFonts+GCMS.swift
@@ -3,7 +3,7 @@
 // swiftformat:disable all
 // Generated using tuist — https://github.com/tuist/tuist
 
-#if os(OSX)
+#if os(macOS)
   import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
@@ -46,7 +46,7 @@ public struct GCMSFontConvertible {
   public let family: String
   public let path: String
 
-  #if os(OSX)
+  #if os(macOS)
   public typealias Font = NSFont
   #elseif os(iOS) || os(tvOS) || os(watchOS)
   public typealias Font = UIFont
@@ -77,7 +77,7 @@ public extension GCMSFontConvertible.Font {
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
-    #elseif os(OSX)
+    #elseif os(macOS)
     if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }

--- a/iOS/Sources/Presentation/Scene/Main/MyPage/View/UserProfileView.swift
+++ b/iOS/Sources/Presentation/Scene/Main/MyPage/View/UserProfileView.swift
@@ -31,6 +31,7 @@ final class UserProfileView: UIView {
     }
     private let userProfileImageView = UIImageView().then {
         $0.layer.cornerRadius = 28
+        $0.layer.masksToBounds = true
     }
     private let userNameLabel = UILabel().then {
         $0.font = UIFont(font: GCMSFontFamily.Inter.bold, size: 14)


### PR DESCRIPTION
## 개요
마이페이지 프로필이미지 원으로 수정하였다.

## 변경전
<img width="293" alt="스크린샷 2023-04-20 오후 7 57 52" src="https://user-images.githubusercontent.com/76590302/233346063-433963a7-ec27-41db-9564-9e6f9f4cd9cd.png">

## 변경후
<img width="291" alt="스크린샷 2023-04-20 오후 5 07 24" src="https://user-images.githubusercontent.com/76590302/233301776-d061a2b8-2434-46e2-9d30-98648c075320.png">
